### PR TITLE
refactor: Refactored code based to make it reuse(다시 재사용할 수 있게 코드 리팩토링)

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,137 +1,78 @@
-import { cpus } from "os";
 import { dirname, resolve, join } from "path";
 import { fileURLToPath } from "url";
 import { Worker } from "jest-worker";
 import fs, { readFileSync } from "fs";
 import JestHasteMap from "jest-haste-map";
 import Resolver from "jest-resolve";
-import yargs from "yargs";
 import { minify } from "terser";
 import { createHash } from "crypto";
 import { createServer } from "http-server";
 
-const root = join(dirname(fileURLToPath(import.meta.url)), "product");
-
-const hasteMapOptions = {
-  extensions: ["js"],
-  maxWorkers: cpus().length,
-  name: "jest-bundler",
-  platforms: [],
-  rootDir: root,
-  roots: [root],
-  id: "Merlin's Bundler",
-};
-
-const hasteMap = new JestHasteMap.default(hasteMapOptions);
-
-await hasteMap.setupCachePath(hasteMapOptions);
-
-const { hasteFS, moduleMap } = await hasteMap.build();
-
-const options = yargs(process.argv).argv;
-
-const entryPoint = resolve(process.cwd(), options.entryPoint);
-
-if (!hasteFS.exists(entryPoint)) {
-  throw new Error(
-    "`--entry-point` does not exist. Please provide a path to a valid file."
-  );
-}
-
-const resolver = new Resolver.default(moduleMap, {
-  extensions: [".js"],
-  hasCoreModules: false,
-  rootDir: root,
-});
-
-const seen = new Set();
-
-const modules = new Map();
-
-const queue = [entryPoint];
-
-let id = 0;
-
-while (queue.length) {
-  const module = queue.shift();
-  if (seen.has(module)) {
-    continue;
+/**
+ * MerlinBunlder is a bundler that uses hasted map( Facebook's haste module system) for collection.
+ *
+ * This implementation is inspired by https://cpojer.net/posts/building-a-javascript-bundler
+ *
+ *
+ * The MerlinBundler is created as follows:
+ *  1. Collection: used jest-haste-map to collection all the dependency of entry point
+ *
+ *  2. Dependency Graph: used jest resolve to resolve haste-map based dependency and transform into bundler based dependency
+ *
+ *  3. Transfromation: used Babel plugin to change modern js syntax into common js or esm
+ *
+ *  4. Optimization: used terser for minification, currently tree shacking is not established
+ *
+ */
+class MerlinBundler {
+  constructor(root, hasteMapOptions, entryPoint, outputs, isDev = false) {
+    this._root = root;
+    this._hasteMapOptions = hasteMapOptions;
+    this._entryPoint = entryPoint;
+    this._outputs = outputs;
+    this._dev = isDev;
   }
-  seen.add(module);
 
-  const dependencyMap = new Map(
-    hasteFS
-      .getDependencies(module)
-      .map((dependencyName) => [
-        dependencyName,
-        resolver.resolveModule(module, dependencyName),
-      ])
-  );
+  static async create({ root, hasteMapOptions, entryPoint, output, isDev }) {
+    const merlinBundler = new MerlinBundler(
+      root,
+      hasteMapOptions,
+      entryPoint,
+      output,
+      isDev
+    );
 
-  const code = fs.readFileSync(module, "utf8");
-  console.log(module);
+    await merlinBundler.setUp(hasteMapOptions);
 
-  const metadata = {
-    id: id++,
-    code,
-    dependencyMap,
-  };
-
-  modules.set(module, metadata);
-
-  queue.push(...dependencyMap.values());
-}
-
-const wrapModule = (id, code) =>
-  `define(${id}, function(module, exports, require) {\n${code}});`;
-
-const worker = new Worker(
-  join(dirname(fileURLToPath(import.meta.url)), "worker.js"),
-  {
-    enableWorkerThreads: true,
+    return merlinBundler;
   }
-);
 
-const results = await Promise.all(
-  Array.from(modules)
-    .reverse()
-    .map(async ([module, metadata]) => {
-      let { id, code } = metadata;
-      ({ code } = await worker.transformFile(code));
-      for (const [dependencyName, dependencyPath] of metadata.dependencyMap) {
-        const dependency = modules.get(dependencyPath);
-        code = code.replace(
-          new RegExp(
-            `require\\(('|")${dependencyName.replace(/[\/.]/g, "\\$&")}\\1\\)`
-          ),
-          `require(${dependency.id})`
-        );
-      }
+  async setUp(hasteMapOptions) {
+    const HasteMap = JestHasteMap.default;
+    this._hasteMap = await HasteMap.create(hasteMapOptions);
 
-      return wrapModule(id, code);
-    })
-);
+    await this._hasteMap.setupCachePath(hasteMapOptions);
+  }
 
-let code = fs.readFileSync("./require.js", "utf8");
+  async bundle() {
+    const { hasteFS, moduleMap } = await this.collection();
+    const dependencyGraph = await this.createDependencyGraph(
+      hasteFS,
+      moduleMap
+    );
+    const transpiledCode = await this.transformation(dependencyGraph);
+    const { filename, url, minifiedCode } = await this.optimization(
+      transpiledCode
+    );
 
-if (options.output) {
-  const outputs = options.output.split(" ");
-  const bundledName = outputs.find((file) => /\.js$/.test(file)).split(".");
-  const htmlName = outputs.find((file) => /\.html$/.test(file));
+    const htmlName =
+      this._outputs.find((file) => /\.html$/.test(file)) ?? "index.html";
 
-  const extension = bundledName.pop();
-  const name = bundledName.shift();
-
-  const bundledCode = [code, ...results, "requireModule(0);"].join("\n");
-
-  const hash = createHash("sha256").update(bundledCode).digest("hex");
-
-  const mapName = [name, hash, extension, "map"].join(".");
-  const filename = [name, hash, extension].join(".");
-
-  fs.writeFileSync(
-    htmlName ?? "index.html",
-    `<!DOCTYPE html>
+    fs.writeFileSync(filename, minifiedCode.code, "utf8");
+    fs.writeFileSync(url, minifiedCode.map, "utf8");
+    fs.writeFileSync(
+      htmlName,
+      `<!DOCTYPE html>
       <html lang="en">
         <head>
           <meta charset="UTF-8" />
@@ -144,38 +85,227 @@ if (options.output) {
         </body>
       </html>
     `,
-    "utf8"
-  );
+      "utf8"
+    );
 
-  if (options.minify) {
-    const minifiedCode = await minify(bundledCode, {
+    if (this._dev) {
+      const server = createServer((req, res) => {
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "text/html");
+        const html = readFileSync("./index.html");
+        res.write(html);
+        res.end();
+      });
+
+      server.listen(5173, "localhost", () => {
+        console.log(`Server is running on http://localhost:5173`);
+      });
+    }
+  }
+
+  /**
+   * 1. collect the modules
+   */
+  async collection() {
+    const { hasteFS, moduleMap } = await this._hasteMap.build();
+
+    return { hasteFS, moduleMap };
+  }
+
+  /**
+   * 2. create dependency graph
+   */
+  async createDependencyGraph(hasteFS, moduleMap) {
+    const resolver = new Resolver.default(moduleMap, {
+      extensions: this._hasteMapOptions.extensions.map((str) => `.${str}`),
+      hasCoreModules: false,
+      rootDir: this._root,
+    });
+
+    const seen = new Set();
+
+    const modules = new Map();
+
+    const queue = [this._entryPoint];
+
+    let id = 0;
+
+    while (queue.length) {
+      const module = queue.shift();
+      if (seen.has(module)) {
+        continue;
+      }
+      seen.add(module);
+
+      const dependencyMap = new Map(
+        hasteFS
+          .getDependencies(module)
+          .map((dependencyName) => [
+            dependencyName,
+            resolver.resolveModule(module, dependencyName),
+          ])
+      );
+
+      const code = fs.readFileSync(module, "utf8");
+
+      const metadata = {
+        id: id++,
+        code,
+        dependencyMap,
+      };
+
+      modules.set(module, metadata);
+
+      queue.push(...dependencyMap.values());
+    }
+
+    return modules;
+  }
+
+  /**
+   * 3. transpile the code into common js or esm
+   */
+  async transformation(dependencyGraph) {
+    const worker = new Worker(
+      join(dirname(fileURLToPath(import.meta.url)), "worker.js"),
+      {
+        enableWorkerThreads: true,
+      }
+    );
+
+    const results = await Promise.all(
+      Array.from(dependencyGraph)
+        .reverse()
+        .map(async ([module, metadata]) => {
+          let { id, code } = metadata;
+          ({ code } = await worker.transformFile(code));
+          for (const [
+            dependencyName,
+            dependencyPath,
+          ] of metadata.dependencyMap) {
+            const dependency = dependencyGraph.get(dependencyPath);
+            code = code.replace(
+              new RegExp(
+                `require\\(('|")${dependencyName.replace(
+                  /[\/.]/g,
+                  "\\$&"
+                )}\\1\\)`
+              ),
+              `require(${dependency.id})`
+            );
+          }
+
+          return MerlinBundler.wrapModule(id, code);
+        })
+    );
+
+    worker.end();
+
+    return results;
+  }
+
+  /**
+   * 4. Optimize the code; tree shaking, minification
+   */
+  async optimization(bundledResult) {
+    const { sourceMapName, hashedFileName, bundledCode } =
+      this.retrieveMetadataForOpt(bundledResult);
+
+    const minifiedCode = await this.minification(
+      bundledCode,
+      hashedFileName,
+      sourceMapName
+    );
+
+    return minifiedCode;
+  }
+
+  async minification(code, filename, url) {
+    const minifiedCode = await minify(code, {
       sourceMap: {
-        filename: filename,
-        url: mapName,
+        filename,
+        url,
         includeSources: true,
       },
     });
 
-    fs.writeFileSync(filename, minifiedCode.code, "utf8");
-    fs.writeFileSync(mapName, minifiedCode.map, "utf8");
-  } else {
-    const minifiedCode = await minify(bundledCode);
-
-    fs.writeFileSync(filename, minifiedCode.code, "utf8");
+    return {
+      filename,
+      url,
+      minifiedCode,
+    };
   }
-  worker.end();
+
+  retrieveMetadataForOpt(bundledResult) {
+    const outputs = this._outputs;
+    const code = fs.readFileSync("./require.js", "utf8");
+
+    const outputFile = outputs.find((file) => /\.js$/.test(file)).split(".");
+
+    const extension = outputFile.pop();
+    const filename = outputFile.shift();
+
+    if (!new Set(this._hasteMapOptions.extensions).has(extension)) {
+      throw new Error("Extension missmatch!");
+    }
+
+    const bundledCode = [code, ...bundledResult, "requireModule(0);"].join(
+      "\n"
+    );
+
+    const hash = createHash("sha256").update(bundledCode).digest("hex");
+
+    const sourceMapName = MerlinBundler.getHashedFileName(
+      filename,
+      hash,
+      extension,
+      true
+    );
+    const hashedFileName = MerlinBundler.getHashedFileName(
+      filename,
+      hash,
+      extension
+    );
+
+    return { sourceMapName, hashedFileName, bundledCode };
+  }
+
+  static getHashedFileName(name, hash, extension, isSourceMap = false) {
+    if (!isSourceMap) {
+      return `${name}.${hash}.${extension}`;
+    }
+
+    return `${name}.${hash}.${extension}.map`;
+  }
+
+  static wrapModule(id, code) {
+    return `define(${id}, function(module, exports, require) {\n${code}});`;
+  }
 }
 
-if (options.dev) {
-  const server = createServer((req, res) => {
-    res.statusCode = 200;
-    res.setHeader("Content-Type", "text/html");
-    const html = readFileSync("./index.html");
-    res.write(html);
-    res.end();
-  });
+const root = join(dirname(fileURLToPath(import.meta.url)), "product");
 
-  server.listen(5173, "localhost", () => {
-    console.log(`Server is running on http://localhost:5173`);
-  });
-}
+const entryPoint = resolve(process.cwd(), "product/entry-point.js");
+
+const output = ["test.js", "index.html"];
+
+const hasteMapOptions = {
+  extensions: ["js"],
+  name: "jest-bundler",
+  platforms: [],
+  rootDir: root,
+  roots: [root],
+  id: "Merlin's Bundler",
+  watch: true,
+  maxWorkers: 4,
+};
+
+const bundler = await MerlinBundler.create({
+  root,
+  hasteMapOptions,
+  entryPoint,
+  output,
+  isDev: true,
+});
+
+await bundler.bundle();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "resetmerlin <resetmerlin@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "start": "node index.mjs --entry-point product/entry-point.js --output 'test.js index.html' --minify",
+    "start": "node index.mjs",
     "dev": "yarn start --dev"
   },
   "dependencies": {


### PR DESCRIPTION
# 작업 내용 요약
## 생각
webpack, rollup 등 같은 번들러들의 특징은 거의 일관된 번들러 과정을 거치는걸로 알고 있어요.
위와 같은 정보는 신용있는 출처인 논문을 참고했습니다. -> https://www.theseus.fi/bitstream/handle/10024/345959/Laurila_Sonja.pdf?sequence=2

![image](https://github.com/user-attachments/assets/f7e478da-eedd-4446-ad7f-f91d748ae0bb)


위 이미지와 같이 번들러 과정은 4가지 과정을 거치는걸로 알고 있습니다. 제 번들러도 이 과정을 무조건 거치도록 해놓았어요. 
하지만 문제점은 보기 어려웠습니다. 그냥 한 줄에 모든 로직을 적다보니(함수 X) 이 코드가 어떤 목적인지 남이 보기 어렵다는 문제가 있어요. 또한 이걸 추상화하여 라이브러리처럼 만들 필요성도 있었습니다. 그래서 이번에 Class 형식을 채택하여 각 메서드에 역할을 부여했어요.

음...  또한 기존에는 cmd를 통해 entry point 및 ouput 상태를 받았다면 

`    "start": "node index.mjs --entry-point product/entry-point.js --output 'test.js index.html' --minify" ` 

이제는 그냥 obj 형식으로 코드에 넣는 방식으로 변경했습니다. 

```tsx

const root = join(dirname(fileURLToPath(import.meta.url)), "product");

const entryPoint = resolve(process.cwd(), "product/entry-point.js");

const output = ["test.js", "index.html"];

const hasteMapOptions = {
  extensions: ["js"],
  name: "jest-bundler",
  platforms: [],
  rootDir: root,
  roots: [root],
  id: "Merlin's Bundler",
  watch: true,
  maxWorkers: 4,
};

const bundler = await MerlinBundler.create({
  root,
  hasteMapOptions,
  entryPoint,
  output,
  isDev: true,
});
```

